### PR TITLE
Add remove method

### DIFF
--- a/rendezvous.go
+++ b/rendezvous.go
@@ -78,6 +78,17 @@ func (h *Hash) GetN(n int, key string) []string {
 	return nodes
 }
 
+// Remove removes a node from the Hash, if it exists
+func (h *Hash) Remove(node string) {
+    nodeBytes := []byte(node)
+    for i, ns := range h.nodes {
+        if bytes.Equal(ns.node, nodeBytes) {
+            h.nodes = append(h.nodes[:i], h.nodes[i+1:]...)
+            return
+        }
+    }
+}
+
 type nodeScores []nodeScore
 
 func (s *nodeScores) Len() int      { return len(*s) }

--- a/rendezvous_test.go
+++ b/rendezvous_test.go
@@ -1,6 +1,7 @@
 package rendezvous
 
 import (
+	"fmt"
 	"reflect"
 	"testing"
 )
@@ -114,5 +115,33 @@ func BenchmarkHashGetN5_10_nodes(b *testing.B) {
 	hash := New("a", "b", "c", "d", "e", "f", "g", "h", "i", "j")
 	for i := 0; i < b.N; i++ {
 		hash.GetN(5, sampleKeys[i%len(sampleKeys)])
+	}
+}
+
+func TestHashRemove(t *testing.T) {
+	hash := New("a", "b", "c")
+
+	var keyForB string
+	for i := 0; i < 10000; i++ {
+		randomKey := fmt.Sprintf("key-%d", i)
+		if hash.Get(randomKey) == "b" {
+			keyForB = randomKey
+			break
+		}
+	}
+
+	if keyForB == "" {
+		t.Fatalf("Failed to find a key that maps to 'b'")
+	}
+
+	hash.Remove("b")
+
+	// Check if the key now maps to a different node
+	newNode := hash.Get(keyForB)
+	if newNode == "b" {
+		t.Errorf("Key %s still maps to removed node 'b'", keyForB)
+	}
+	if newNode == "" {
+		t.Errorf("Key %s does not map to any node after removing 'b'", keyForB)
 	}
 }


### PR DESCRIPTION
for the distributed hashing use-case we have to occasionally remove nodes from the nodelist. It obviously wouldn't affect prior object hashing, and a client would have to recalculate them. But at least it is easier then nuking the hash, and recreating it from scratch.



- [ x] I acknowledge that all my contributions will be made under the project's license.
