### PR TITLE
GetN scores/sorts a copy; TestGetNPreservesAddOrder

### DIFF
--- a/rendezvous.go
+++ b/rendezvous.go
@@ -59,24 +59,26 @@ func (h *Hash) Get(key string) string {
 }
 
 // GetN returns no more than n nodes for the given key, ordered by descending
-// score. GetN is not goroutine-safe.
+// score. It does not reorder the internal node list. GetN is not goroutine-safe.
 func (h *Hash) GetN(n int, key string) []string {
 	if n < 0 {
 		n = 0
 	}
 	keyBytes := unsafeBytes(key)
-	for i := 0; i < len(h.nodes); i++ {
-		h.nodes[i].score = h.hash(h.nodes[i].node, keyBytes)
+	scored := make(nodeScores, len(h.nodes))
+	copy(scored, h.nodes)
+	for i := range scored {
+		scored[i].score = h.hash(scored[i].node, keyBytes)
 	}
-	sort.Sort(&h.nodes)
+	sort.Sort(&scored)
 
-	if n > len(h.nodes) {
-		n = len(h.nodes)
+	if n > len(scored) {
+		n = len(scored)
 	}
 
 	nodes := make([]string, n)
 	for i := range nodes {
-		nodes[i] = string(h.nodes[i].node)
+		nodes[i] = string(scored[i].node)
 	}
 	return nodes
 }

--- a/rendezvous_test.go
+++ b/rendezvous_test.go
@@ -63,6 +63,20 @@ type getNTestcase struct {
 	expectedNodes []string
 }
 
+func TestGetNPreservesAddOrder(t *testing.T) {
+	hash := New("z", "a", "m")
+	_ = hash.GetN(2, "foo")
+	if len(hash.nodes) != 3 {
+		t.Fatalf("len(nodes) = %d, want 3", len(hash.nodes))
+	}
+	want := []string{"z", "a", "m"}
+	for i, name := range want {
+		if string(hash.nodes[i].node) != name {
+			t.Fatalf("after GetN, node[%d] = %q, want %q", i, hash.nodes[i].node, name)
+		}
+	}
+}
+
 func Test_Hash_GetN(t *testing.T) {
 	hash := New()
 


### PR DESCRIPTION
## Summary
`GetN` scores and sorts a copy of node state; add `TestGetNPreservesAddOrder`.

## Stack
PR 5 of 8. Base: `pr/document-unsafe-bytes`.

Made with [Cursor](https://cursor.com)