### PR TITLE
Add skips duplicates; doc + TestAddDedupeNodes

### DIFF
--- a/rendezvous.go
+++ b/rendezvous.go
@@ -41,13 +41,26 @@ func New(nodes ...string) *Hash {
 	return h
 }
 
-// Add adds additional nodes to the Hash.
+// Add adds additional nodes to the Hash. Duplicate node names are ignored.
 func (h *Hash) Add(nodes ...string) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 	for _, node := range nodes {
-		h.nodes = append(h.nodes, nodeScore{node: []byte(node)})
+		b := []byte(node)
+		if h.hasNodeBytes(b) {
+			continue
+		}
+		h.nodes = append(h.nodes, nodeScore{node: b})
 	}
+}
+
+func (h *Hash) hasNodeBytes(b []byte) bool {
+	for _, ns := range h.nodes {
+		if bytes.Equal(ns.node, b) {
+			return true
+		}
+	}
+	return false
 }
 
 // Get returns the node with the highest score for the given key. If this Hash

--- a/rendezvous_test.go
+++ b/rendezvous_test.go
@@ -20,6 +20,13 @@ type getTestcase struct {
 	expectedNode string
 }
 
+func TestAddDedupesNodes(t *testing.T) {
+	hash := New("a", "b", "a", "b", "c")
+	if len(hash.nodes) != 3 {
+		t.Fatalf("len(nodes) = %d, want 3 (unique a,b,c)", len(hash.nodes))
+	}
+}
+
 func TestHashConcurrentGet(t *testing.T) {
 	hash := New("a", "b", "c", "d", "e")
 	const goroutines = 64


### PR DESCRIPTION
## Summary
`Add` skips duplicate nodes; documentation and `TestAddDedupeNodes`.

## Stack
PR 8 of 8. Base: `pr/getn-topk-heap`.

Made with [Cursor](https://cursor.com)